### PR TITLE
feat(ci): add GoReleaser configuration and integrate with semantic-release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@
 # project
 .env
 .gic
+
+dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,46 @@
+# This is an example .goreleaser.yml file with some sensible defaults.
+# Make sure to check the documentation at https://goreleaser.com
+
+# The lines below are called `modelines`. See `:help modeline`
+# Feel free to remove those if you don't want/need to use them.
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+# vim: set ts=2 sw=2 tw=0 fo=cnqoj
+
+version: 2
+
+before:
+  hooks:
+    # You may remove this if you don't use go modules.
+    - go mod tidy
+    # you may remove this if you don't need go generate
+    - go generate ./...
+
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+
+archives:
+  - format: tar.gz
+    # this name template makes the OS and Arch compatible with the results of `uname`.
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+    # use zip for windows archives
+    format_overrides:
+      - goos: windows
+        format: zip
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"

--- a/.releaserc
+++ b/.releaserc
@@ -6,3 +6,7 @@ plugins:
 - "@semantic-release/release-notes-generator"
 - "@semantic-release/changelog"
 - "@semantic-release/git"
+- - "@semantic-release/exec"
+  - publishCmd: |
+      echo "${nextRelease.notes}" > /tmp/release-notes.md
+      goreleaser release --release-notes /tmp/release-notes.md --clean

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
             "request": "launch",
             "mode": "auto",
             "program": "cmd/gic/main.go",
-            "cwd": "/workspaces/gic",
+            "cwd": "/workspaces/gic"
         }
     ]
 }

--- a/cmd/gic/main.go
+++ b/cmd/gic/main.go
@@ -21,6 +21,11 @@ func main() {
 				log.Fatal(err)
 			}
 
+			err = config.ValidateConfig(cfg)
+			if err != nil {
+				log.Fatal(err)
+			}
+
 			gitDiff, err := git.GetStagedChanges()
 			if err != nil {
 				log.Fatal(err)
@@ -33,7 +38,6 @@ func main() {
 			}
 
 			// retrieve the commit message
-			// if the connection type is azure/azure_ad
 			commitMessage, err := llm.GenerateCommitMessage(cfg, gitDiff)
 			if err != nil {
 				log.Fatal(err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,6 +1,9 @@
 package config
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/spf13/viper"
 )
 
@@ -30,4 +33,75 @@ func LoadConfig() (Config, error) {
 		return cfg, err
 	}
 	return cfg, nil
+}
+
+func ValidateConfig(cfg Config) error {
+	if cfg.LLMInstructions == "" {
+		fmt.Println("LLMInstructions not set in config. Using default instructions.")
+		cfg.LLMInstructions = "You are a helpful assistant, that helps generating commit messages based on git diffs."
+	}
+
+	if err := validateAPIKey(cfg); err != nil {
+		return err
+	}
+
+	if err := validateAzureEndpoint(cfg); err != nil {
+		return err
+	}
+
+	if err := validateTokens(cfg); err != nil {
+		return err
+	}
+
+	if err := validateModelDeploymentName(cfg); err != nil {
+		return err
+	}
+
+	if err := validateApiVersion(cfg); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func validateAPIKey(cfg Config) error {
+	if cfg.ConnectionType == "azure" || cfg.ConnectionType == "openai" {
+		if os.Getenv("API_KEY") == "" {
+			return fmt.Errorf("API_KEY environment variable not set")
+		}
+	}
+	return nil
+}
+
+func validateAzureEndpoint(cfg Config) error {
+	if cfg.ConnectionType == "azure" || cfg.ConnectionType == "azure_ad" {
+		if cfg.AzureEndpoint == "" {
+			return fmt.Errorf("AzureEndpoint not set in config")
+		}
+	}
+	return nil
+}
+
+func validateTokens(cfg Config) error {
+	if cfg.Tokens == 0 {
+		fmt.Println("Tokens not set in config. Using default value 4000.")
+		cfg.Tokens = 4000
+	}
+	return nil
+}
+
+func validateModelDeploymentName(cfg Config) error {
+	if cfg.ModelDeploymentName == "" {
+		fmt.Println("ModelDeploymentName not set in config. Using default value gpt-4o.")
+		cfg.ModelDeploymentName = "gpt-4o"
+	}
+	return nil
+}
+
+func validateApiVersion(cfg Config) error {
+	if cfg.ApiVersion == "" {
+		fmt.Println("ApiVersion not set in config. Using default value 2024-02-15-preview.")
+		cfg.ApiVersion = "2024-02-15-preview"
+	}
+	return nil
 }

--- a/internal/llm/llm.go
+++ b/internal/llm/llm.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/ai/azopenai"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/jsburckhardt/gic/internal/config"
@@ -15,10 +16,6 @@ import (
 )
 
 func GenerateCommitMessage(cfg config.Config, diff string) (string, error) {
-	err := validateConfig(cfg)
-	if err != nil {
-		return "", err
-	}
 	apikey := os.Getenv("API_KEY")
 	switch cfg.ConnectionType {
 	case "azure":
@@ -33,20 +30,68 @@ func GenerateCommitMessage(cfg config.Config, diff string) (string, error) {
 }
 
 func GenerateCommitMessageAzure(apikey string, cfg config.Config, diff string) (string, error) {
-	return "", fmt.Errorf("not implemented")
+	maxTokens := int32(cfg.Tokens)
+	keyCredential := azcore.NewKeyCredential(apikey)
+
+	client, err := azopenai.NewClientWithKeyCredential(cfg.AzureEndpoint, keyCredential, nil)
+
+	if err != nil {
+		log.Printf("ERROR: %s", err)
+		return "", err
+	}
+
+	messages := []azopenai.ChatRequestMessageClassification{
+		&azopenai.ChatRequestSystemMessage{Content: to.Ptr(cfg.LLMInstructions)},
+		&azopenai.ChatRequestUserMessage{Content: azopenai.NewChatRequestUserMessageContent("git commit diff: " + diff)},
+	}
+
+	resp, err := client.GetChatCompletions(context.TODO(), azopenai.ChatCompletionsOptions{
+		Messages:       messages,
+		DeploymentName: &(cfg.ModelDeploymentName),
+		MaxTokens:      &maxTokens,
+	}, nil)
+
+	if err != nil {
+		log.Printf("ERROR: %s", err)
+		return "", err
+	}
+
+	// var choice azopenai.ChatChoice
+	var messageContent string
+	for _, choice := range resp.Choices {
+		if choice.ContentFilterResults != nil {
+
+			if choice.ContentFilterResults.Error != nil {
+				fmt.Fprintf(os.Stderr, "  Error:%v\n", choice.ContentFilterResults.Error)
+			}
+
+			// TODO: Include in logger
+			// fmt.Fprintf(os.Stderr, "Content filter results\n")
+			// fmt.Fprintf(os.Stderr, "  Hate: sev: %v, filtered: %v\n", *choice.ContentFilterResults.Hate.Severity, *choice.ContentFilterResults.Hate.Filtered)
+			// fmt.Fprintf(os.Stderr, "  SelfHarm: sev: %v, filtered: %v\n", *choice.ContentFilterResults.SelfHarm.Severity, *choice.ContentFilterResults.SelfHarm.Filtered)
+			// fmt.Fprintf(os.Stderr, "  Sexual: sev: %v, filtered: %v\n", *choice.ContentFilterResults.Sexual.Severity, *choice.ContentFilterResults.Sexual.Filtered)
+			// fmt.Fprintf(os.Stderr, "  Violence: sev: %v, filtered: %v\n", *choice.ContentFilterResults.Violence.Severity, *choice.ContentFilterResults.Violence.Filtered)
+		}
+
+		// TODO: Include in logger
+		// if choice.Message != nil && choice.Message.Content != nil {
+		// 	fmt.Fprintf(os.Stderr, "Content[%d]: %s\n", *choice.Index, *choice.Message.Content)
+		// }
+
+		// TODO: Include in logger
+		// if choice.FinishReason != nil {
+		//// this choice's conversation is complete.
+		// 	fmt.Fprintf(os.Stderr, "Finish reason[%d]: %s\n", *choice.Index, *choice.FinishReason)
+		// }
+		messageContent = *choice.Message.Content
+	}
+
+	return messageContent, nil
 }
 
 func GenerateCommitMessageAzureAD(cfg config.Config, diff string) (string, error) {
-
-	// const azureOpenAIEndpoint = "https://generic-aoai-01.openai.azure.com/"
-	// The latest API versions, including previews, can be found here:
-	// https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#rest-api-versioning
-	// const azureOpenAIAPIVersion = "2024-02-15-preview"
-	// modelDeploymentID := "gpt-4o"
 	maxTokens := int32(cfg.Tokens)
-
 	tokenCredential, err := azidentity.NewDefaultAzureCredential(nil)
-
 	if err != nil {
 		fmt.Printf("Failed to create the DefaultAzureCredential: %s", err)
 		os.Exit(1)
@@ -123,75 +168,4 @@ func GenerateCommitMessageOpenAI(apiKey string, cfg config.Config, diff string) 
 		panic(err.Error())
 	}
 	return chatCompletion.Choices[0].Message.Content, nil
-}
-
-func validateConfig(cfg config.Config) error {
-	if cfg.LLMInstructions == "" {
-		fmt.Println("LLMInstructions not set in config. Using default instructions.")
-		cfg.LLMInstructions = "You are a helpful assistant, that helps generating commit messages based on git diffs."
-	}
-
-	if err := validateAPIKey(cfg); err != nil {
-		return err
-	}
-
-	if err := validateAzureEndpoint(cfg); err != nil {
-		return err
-	}
-
-	if err := validateTokens(cfg); err != nil {
-		return err
-	}
-
-	if err := validateModelDeploymentName(cfg); err != nil {
-		return err
-	}
-
-	if err := validateApiVersion(cfg); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func validateAPIKey(cfg config.Config) error {
-	if cfg.ConnectionType == "azure" || cfg.ConnectionType == "openai" {
-		if os.Getenv("API_KEY") == "" {
-			return fmt.Errorf("API_KEY environment variable not set")
-		}
-	}
-	return nil
-}
-
-func validateAzureEndpoint(cfg config.Config) error {
-	if cfg.ConnectionType == "azure" || cfg.ConnectionType == "azure_ad" {
-		if cfg.AzureEndpoint == "" {
-			return fmt.Errorf("AzureEndpoint not set in config")
-		}
-	}
-	return nil
-}
-
-func validateTokens(cfg config.Config) error {
-	if cfg.Tokens == 0 {
-		fmt.Println("Tokens not set in config. Using default value 4000.")
-		cfg.Tokens = 4000
-	}
-	return nil
-}
-
-func validateModelDeploymentName(cfg config.Config) error {
-	if cfg.ModelDeploymentName == "" {
-		fmt.Println("ModelDeploymentName not set in config. Using default value gpt-4o.")
-		cfg.ModelDeploymentName = "gpt-4o"
-	}
-	return nil
-}
-
-func validateApiVersion(cfg config.Config) error {
-	if cfg.ApiVersion == "" {
-		fmt.Println("ApiVersion not set in config. Using default value 2024-02-15-preview.")
-		cfg.ApiVersion = "2024-02-15-preview"
-	}
-	return nil
 }


### PR DESCRIPTION
- Add `.goreleaser.yaml` with configuration for building and releasing binaries.
- Update `.releaserc` to include `@semantic-release/exec` plugin for running GoReleaser with release notes.
- Update `.gitignore` to include `dist/` directory.
- Add validation for configuration in `config.go` including API key, Azure endpoint, tokens, model deployment name, and API version.
- Implement `GenerateCommitMessageAzure` function in `llm.go` for generating commit messages using Azure OpenAI.
- Remove redundant validation from `llm.go` and refactor validation logic to `config.go`.
- Update VSCode launch configuration to include `API_KEY` environment variable.