### PR TITLE
feat(init): add main package and command execution

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,7 +13,7 @@
 		"ghcr.io/stuartleeks/dev-container-features/shell-history:0": {},
 		"ghcr.io/devcontainers/features/azure-cli:1": {
 			"installBicep": true
-		},
+		}
         // "ghcr.io/prulloac/devcontainer-features/ollama:1": {
         //     "pull": "phi3"
         // }
@@ -44,6 +44,35 @@
 				"files.insertFinalNewline": true,
 				"github.copilot.enable": {
 					"markdown": true
+				},
+				"go.toolsManagement.checkForUpdates": "local",
+				"go.useLanguageServer": true,
+				"go.gopath": "/go",
+				"go.lintTool": "revive",
+				"go.goroot": "/usr/local/go",
+				"go.lintFlags": [
+					"--fast"
+				],
+				"[go]": {
+					"editor.formatOnSave": true,
+					"editor.codeActionsOnSave": {
+						"source.organizeImports": "always"
+					},
+					// Optional: Disable snippets, as they conflict with completion ranking.
+					"editor.snippetSuggestions": "none"
+				},
+				"[go.mod]": {
+					"editor.formatOnSave": true,
+					"editor.codeActionsOnSave": {
+						"source.organizeImports": "always"
+					}
+				},
+				"gopls": {
+					// Add parameter placeholders when completing a function.
+					"usePlaceholders": true,
+					// If true, enable additional analyses with staticcheck.
+					// Warning: This will significantly increase memory usage.
+					"staticcheck": false
 				}
 			}
 		}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,6 +31,7 @@ jobs:
   test:
     name: Run Tests
     runs-on: ubuntu-latest
+    needs: lint
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3

--- a/.gitignore
+++ b/.gitignore
@@ -36,5 +36,6 @@
 # project
 .env
 .gic
+gic
 
 dist/

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,6 +17,10 @@ linters-settings:
 
   revive:
     enable-all-rules: true
+    rules:
+      - name: "line-length-limit"
+        arguments:
+          - 120
 
   staticcheck:
     checks: ["all"]
@@ -56,5 +60,5 @@ linters:
 
 output:
   formats: 
-    - format: colored-line-number
+    - format: colored-tab
   sort-results: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -45,6 +45,7 @@ issues:
 linters:
   enable:
     - govet
+    - revive
     - errcheck
     - staticcheck
     - gocyclo

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -13,7 +13,7 @@ before:
     # You may remove this if you don't use go modules.
     - go mod tidy
     # you may remove this if you don't need go generate
-    - go generate ./...
+    # - go generate ./...
 
 builds:
   - env:

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,7 @@
             "type": "go",
             "request": "launch",
             "mode": "auto",
-            "program": "cmd/gic/main.go",
+            "program": "main.go",
             "cwd": "/workspaces/gic"
         }
     ]

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,17 +1,34 @@
-package main
+package cmd
 
 import (
 	"fmt"
 	"log"
 	"os"
 
-	"github.com/jsburckhardt/gic/internal/config"
-	"github.com/jsburckhardt/gic/internal/git"
-	"github.com/jsburckhardt/gic/internal/llm"
+	"gic/internal/config"
+	"gic/internal/git"
+	"gic/internal/llm"
+
 	"github.com/spf13/cobra"
 )
 
-func main() {
+var (
+	hash    string
+	verbose bool
+
+	rootCmd = &cobra.Command{
+		Use:   "gic",
+		Short: "gic",
+		Long:  "gic generates git commit messages based on staged changes.",
+	}
+)
+
+func Execute(version, commit string) {
+	rootCmd.Version = version
+	hash = commit
+
+	setVersion()
+
 	var rootCmd = &cobra.Command{
 		Use:   "gic",
 		Short: "gic generates git commit messages based on staged changes.",
@@ -51,4 +68,14 @@ func main() {
 		fmt.Println(err)
 		os.Exit(1)
 	}
+}
+
+func setVersion() {
+	template := fmt.Sprintf("gic version: %s commit: %s \n", rootCmd.Version, hash)
+	rootCmd.SetVersionTemplate(template)
+}
+
+func init() {
+	cobra.OnInitialize()
+	rootCmd.PersistentFlags().BoolVar(&verbose, "verbose", false, "set logging level to verbose")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,8 +3,6 @@ package cmd
 
 import (
 	"fmt"
-	"log"
-	"os"
 
 	"gic/internal/config"
 	"gic/internal/git"
@@ -13,7 +11,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const exitCodeFailure = 1
+// const exitCodeFailure = 1
 
 var (
 	hash    string
@@ -27,7 +25,7 @@ var (
 )
 
 // Execute runs the root command of the application.
-func Execute(version, commit string) {
+func Execute(version, commit string) error {
 	rootCmd.Version = version
 	hash = commit
 
@@ -36,34 +34,37 @@ func Execute(version, commit string) {
 	rootCmd = &cobra.Command{
 		Use:   "gic",
 		Short: "gic generates git commit messages based on staged changes.",
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			_ = cmd
 			_ = args
 			cfg, err := config.LoadConfig()
 			if err != nil {
-				log.Fatal(err)
+				return err
 			}
 
 			gitDiff, err := git.GetStagedChanges()
 			if err != nil {
-				log.Fatal(err)
+				return err
 			}
 
 			// retrieve the commit message
 			commitMessage, err := llm.GenerateCommitMessage(cfg, gitDiff)
 			if err != nil {
-				log.Fatal(err)
+				return err
 			}
 
 			_, _ = fmt.Println("Suggested Commit Message:", commitMessage)
+			return nil
 		},
 	}
 
 	// Execute the root command
 	if err := rootCmd.Execute(); err != nil {
-		log.Fatal(err)
-		os.Exit(exitCodeFailure)
+		// log.Fatal(err)
+		return err
+		// os.Exit(exitCodeFailure)
 	}
+	return nil
 }
 
 func setVersion() {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,3 +1,4 @@
+// Package cmd provides the command-line interface for the gic application.
 package cmd
 
 import (
@@ -23,6 +24,7 @@ var (
 	}
 )
 
+// Execute runs the root command of the application.
 func Execute(version, commit string) {
 	rootCmd.Version = version
 	hash = commit
@@ -64,6 +66,7 @@ func Execute(version, commit string) {
 		},
 	}
 
+	// Execute the root command
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)
 		os.Exit(1)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -13,6 +13,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const exitCodeFailure = 1
+
 var (
 	hash    string
 	verbose bool
@@ -31,16 +33,13 @@ func Execute(version, commit string) {
 
 	setVersion()
 
-	var rootCmd = &cobra.Command{
+	rootCmd = &cobra.Command{
 		Use:   "gic",
 		Short: "gic generates git commit messages based on staged changes.",
 		Run: func(cmd *cobra.Command, args []string) {
+			_ = cmd
+			_ = args
 			cfg, err := config.LoadConfig()
-			if err != nil {
-				log.Fatal(err)
-			}
-
-			err = config.ValidateConfig(cfg)
 			if err != nil {
 				log.Fatal(err)
 			}
@@ -50,26 +49,20 @@ func Execute(version, commit string) {
 				log.Fatal(err)
 			}
 
-			// if diff is empty finish
-			if gitDiff == "" {
-				fmt.Println("No staged changes found.")
-				return
-			}
-
 			// retrieve the commit message
 			commitMessage, err := llm.GenerateCommitMessage(cfg, gitDiff)
 			if err != nil {
 				log.Fatal(err)
 			}
 
-			fmt.Println("Suggested Commit Message:", commitMessage)
+			_, _ = fmt.Println("Suggested Commit Message:", commitMessage)
 		},
 	}
 
 	// Execute the root command
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+		log.Fatal(err)
+		os.Exit(exitCodeFailure)
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/jsburckhardt/gic
+module gic
 
 go 1.23.0
 
@@ -7,6 +7,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.14.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.7.0
 	github.com/joho/godotenv v1.5.1
+	github.com/jsburckhardt/gic v1.0.0
 	github.com/openai/openai-go v0.1.0-alpha.9
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/viper v1.19.0

--- a/go.sum
+++ b/go.sum
@@ -29,6 +29,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
+github.com/jsburckhardt/gic v1.0.0 h1:0cV5NiWUJtjVNl3YEYT3ipBUKEDl/5/3x5MnLUIZs8w=
+github.com/jsburckhardt/gic v1.0.0/go.mod h1:jM3MILCAIdDF4uftsIBDGEHFepFXKLrjYEFFlY96+Ts=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1,3 +1,4 @@
+// Package cli provides a command-line interface for the application.
 package cli
 
 import (
@@ -7,6 +8,9 @@ import (
 	"github.com/joho/godotenv"
 )
 
+// LoadEnv loads environment variables from a .env file.
+// It attempts to load the .env file located in the current working directory.
+// If the file is not found or there is an error loading the file, it will cause a fatal error.
 func LoadEnv() {
 	err := godotenv.Load(".env")
 	if err != nil {
@@ -14,10 +18,12 @@ func LoadEnv() {
 	}
 }
 
+// GetAPIKey returns the API key from the environment variables.
 func GetAPIKey() string {
 	return os.Getenv("API_KEY")
 }
 
+// GetAzureOpenAIEndpoint returns the Azure OpenAI endpoint from the environment variables.
 func GetAzureOpenAIEndpoint() string {
 	return os.Getenv("AZURE_OPENAI_ENDPOINT")
 }

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -2,7 +2,6 @@
 package cli
 
 import (
-	"log"
 	"os"
 
 	"github.com/joho/godotenv"
@@ -10,12 +9,14 @@ import (
 
 // LoadEnv loads environment variables from a .env file.
 // It attempts to load the .env file located in the current working directory.
-// If the file is not found or there is an error loading the file, it will cause a fatal error.
-func LoadEnv() {
+// If the file is not found or there is an error loading the file,
+// it will cause a fatal error.
+func LoadEnv() error {
 	err := godotenv.Load(".env")
 	if err != nil {
-		log.Fatal("Error loading .env file")
+		return err
 	}
+	return nil
 }
 
 // GetAPIKey returns the API key from the environment variables.
@@ -23,7 +24,8 @@ func GetAPIKey() string {
 	return os.Getenv("API_KEY")
 }
 
-// GetAzureOpenAIEndpoint returns the Azure OpenAI endpoint from the environment variables.
+// GetAzureOpenAIEndpoint returns the Azure OpenAI endpoint
+// from the environment variables.
 func GetAzureOpenAIEndpoint() string {
 	return os.Getenv("AZURE_OPENAI_ENDPOINT")
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,3 +1,4 @@
+// Package config provides functionality for managing configuration settings.
 package config
 
 import (
@@ -7,9 +8,10 @@ import (
 	"github.com/spf13/viper"
 )
 
+// Config represents the configuration structure for the application.
 type Config struct {
 	ModelDeploymentName string `mapstructure:"model_deployment_name"`
-	ApiVersion          string `mapstructure:"api_version"`
+	APIVersion          string `mapstructure:"api_version"`
 	LLMInstructions     string `mapstructure:"llm_instructions"`
 	ConnectionType      string `mapstructure:"connection_type"`
 	AzureEndpoint       string `mapstructure:"azure_endpoint"`
@@ -17,6 +19,7 @@ type Config struct {
 	Tokens              int    `mapstructure:"tokens"`
 }
 
+// LoadConfig loads the configuration from a YAML file and returns a Config struct.
 func LoadConfig() (Config, error) {
 	var cfg Config
 
@@ -35,6 +38,7 @@ func LoadConfig() (Config, error) {
 	return cfg, nil
 }
 
+// ValidateConfig validates the configuration and returns an error if any validation fails.
 func ValidateConfig(cfg Config) error {
 	if cfg.LLMInstructions == "" {
 		fmt.Println("LLMInstructions not set in config. Using default instructions.")
@@ -57,7 +61,7 @@ func ValidateConfig(cfg Config) error {
 		return err
 	}
 
-	if err := validateApiVersion(cfg); err != nil {
+	if err := validateAPIVersion(cfg); err != nil {
 		return err
 	}
 
@@ -98,10 +102,10 @@ func validateModelDeploymentName(cfg Config) error {
 	return nil
 }
 
-func validateApiVersion(cfg Config) error {
-	if cfg.ApiVersion == "" {
+func validateAPIVersion(cfg Config) error {
+	if cfg.APIVersion == "" {
 		fmt.Println("ApiVersion not set in config. Using default value 2024-02-15-preview.")
-		cfg.ApiVersion = "2024-02-15-preview"
+		cfg.APIVersion = "2024-02-15-preview"
 	}
 	return nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,6 +8,10 @@ import (
 	"github.com/spf13/viper"
 )
 
+const emptyString = ""
+const zeroTokens = 0
+const defaultTokens = 4000
+
 // Config represents the configuration structure for the application.
 type Config struct {
 	ModelDeploymentName string `mapstructure:"model_deployment_name"`
@@ -19,7 +23,8 @@ type Config struct {
 	Tokens              int    `mapstructure:"tokens"`
 }
 
-// LoadConfig loads the configuration from a YAML file and returns a Config struct.
+// LoadConfig loads the configuration from a YAML file and
+// returns a Config struct.
 func LoadConfig() (Config, error) {
 	var cfg Config
 
@@ -35,14 +40,20 @@ func LoadConfig() (Config, error) {
 	if err := viper.Unmarshal(&cfg); err != nil {
 		return cfg, err
 	}
+	if err := validateConfig(cfg); err != nil {
+		return cfg, err
+	}
 	return cfg, nil
 }
 
-// ValidateConfig validates the configuration and returns an error if any validation fails.
-func ValidateConfig(cfg Config) error {
-	if cfg.LLMInstructions == "" {
-		fmt.Println("LLMInstructions not set in config. Using default instructions.")
-		cfg.LLMInstructions = "You are a helpful assistant, that helps generating commit messages based on git diffs."
+// ValidateConfig validates the configuration and returns an
+// error if any validation fails.
+func validateConfig(cfg Config) error {
+	_, _ = fmt.Println("Validating configuration...")
+	if cfg.LLMInstructions == emptyString {
+		_, _ = fmt.Println("LLMInstructions not set in config. Using default instructions.")
+		cfg.LLMInstructions = "You are a helpful assistant, " +
+			"that helps generating commit messages based on git diffs."
 	}
 
 	if err := validateAPIKey(cfg); err != nil {
@@ -61,16 +72,12 @@ func ValidateConfig(cfg Config) error {
 		return err
 	}
 
-	if err := validateAPIVersion(cfg); err != nil {
-		return err
-	}
-
-	return nil
+	return validateAPIVersion(cfg)
 }
 
 func validateAPIKey(cfg Config) error {
 	if cfg.ConnectionType == "azure" || cfg.ConnectionType == "openai" {
-		if os.Getenv("API_KEY") == "" {
+		if os.Getenv("API_KEY") == emptyString {
 			return fmt.Errorf("API_KEY environment variable not set")
 		}
 	}
@@ -79,7 +86,7 @@ func validateAPIKey(cfg Config) error {
 
 func validateAzureEndpoint(cfg Config) error {
 	if cfg.ConnectionType == "azure" || cfg.ConnectionType == "azure_ad" {
-		if cfg.AzureEndpoint == "" {
+		if cfg.AzureEndpoint == emptyString {
 			return fmt.Errorf("AzureEndpoint not set in config")
 		}
 	}
@@ -87,24 +94,24 @@ func validateAzureEndpoint(cfg Config) error {
 }
 
 func validateTokens(cfg Config) error {
-	if cfg.Tokens == 0 {
-		fmt.Println("Tokens not set in config. Using default value 4000.")
-		cfg.Tokens = 4000
+	if cfg.Tokens == zeroTokens {
+		_, _ = fmt.Println("Tokens not set in config. Using default value 4000.")
+		cfg.Tokens = defaultTokens
 	}
 	return nil
 }
 
 func validateModelDeploymentName(cfg Config) error {
-	if cfg.ModelDeploymentName == "" {
-		fmt.Println("ModelDeploymentName not set in config. Using default value gpt-4o.")
+	if cfg.ModelDeploymentName == emptyString {
+		_, _ = fmt.Println("ModelDeploymentName not set in config. Using default value gpt-4o.")
 		cfg.ModelDeploymentName = "gpt-4o"
 	}
 	return nil
 }
 
 func validateAPIVersion(cfg Config) error {
-	if cfg.APIVersion == "" {
-		fmt.Println("ApiVersion not set in config. Using default value 2024-02-15-preview.")
+	if cfg.APIVersion == emptyString {
+		_, _ = fmt.Println("ApiVersion not set in config. Using default value 2024-02-15-preview.")
 		cfg.APIVersion = "2024-02-15-preview"
 	}
 	return nil

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -1,14 +1,18 @@
+// Package git provides functions for interacting with Git repositories.
 package git
 
 import (
-    "os/exec"
+	"os/exec"
 )
 
+// GetStagedChanges returns the staged changes in the git repository.
+// It executes the "git diff --cached" command and returns the output as a string.
+// If an error occurs during the execution of the command, it returns an empty string and the error.
 func GetStagedChanges() (string, error) {
-    cmd := exec.Command("git", "diff", "--cached")
-    out, err := cmd.Output()
-    if err != nil {
-        return "", err
-    }
-    return string(out), nil
+	cmd := exec.Command("git", "diff", "--cached")
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
 }

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -3,7 +3,7 @@ package git_test
 import (
 	"testing"
 
-	"github.com/jsburckhardt/gic/internal/git"
+	"gic/internal/git"
 )
 
 func TestGetStagedChanges(t *testing.T) {

--- a/internal/llm/llm.go
+++ b/internal/llm/llm.go
@@ -24,6 +24,11 @@ import (
 // Supported connection types are "azure", "azure_ad", and "openai".
 // If the connection type is not supported, the function returns an empty string and an error indicating the unsupported connection type.
 func GenerateCommitMessage(cfg config.Config, diff string) (string, error) {
+	// if diff is empty finish
+	if diff == "" {
+		return "### NO STAGED CHAGES ###", nil
+	}
+
 	apikey := os.Getenv("API_KEY")
 	switch cfg.ConnectionType {
 	case "azure":
@@ -75,33 +80,19 @@ func GenerateCommitMessageAzure(apikey string, cfg config.Config, diff string) (
 				fmt.Fprintf(os.Stderr, "  Error:%v\n", choice.ContentFilterResults.Error)
 			}
 
-			// TODO: Include in logger
-			// fmt.Fprintf(os.Stderr, "Content filter results\n")
-			// fmt.Fprintf(os.Stderr, "  Hate: sev: %v, filtered: %v\n", *choice.ContentFilterResults.Hate.Severity, *choice.ContentFilterResults.Hate.Filtered)
-			// fmt.Fprintf(os.Stderr, "  SelfHarm: sev: %v, filtered: %v\n", *choice.ContentFilterResults.SelfHarm.Severity, *choice.ContentFilterResults.SelfHarm.Filtered)
-			// fmt.Fprintf(os.Stderr, "  Sexual: sev: %v, filtered: %v\n", *choice.ContentFilterResults.Sexual.Severity, *choice.ContentFilterResults.Sexual.Filtered)
-			// fmt.Fprintf(os.Stderr, "  Violence: sev: %v, filtered: %v\n", *choice.ContentFilterResults.Violence.Severity, *choice.ContentFilterResults.Violence.Filtered)
 		}
 
-		// TODO: Include in logger
-		// if choice.Message != nil && choice.Message.Content != nil {
-		// 	fmt.Fprintf(os.Stderr, "Content[%d]: %s\n", *choice.Index, *choice.Message.Content)
-		// }
-
-		// TODO: Include in logger
-		// if choice.FinishReason != nil {
-		//// this choice's conversation is complete.
-		// 	fmt.Fprintf(os.Stderr, "Finish reason[%d]: %s\n", *choice.Index, *choice.FinishReason)
-		// }
 		messageContent = *choice.Message.Content
 	}
 
 	return messageContent, nil
 }
 
-// GenerateCommitMessageAzureAD generates a commit message using the Azure Language Learning
-// Model with Azure Active Directory authentication.
-// It takes a config.Config object and a string representing the diff as input.
+// GenerateCommitMessageAzureAD generates a commit message using
+// the Azure Language Learning Model with Azure Active Directory
+// authentication.
+// It takes a config.Config object and a string representing
+// the diff as input.
 func GenerateCommitMessageAzureAD(cfg config.Config, diff string) (string, error) {
 	maxTokens := int32(cfg.Tokens)
 	tokenCredential, err := azidentity.NewDefaultAzureCredential(nil)

--- a/internal/llm/llm.go
+++ b/internal/llm/llm.go
@@ -37,6 +37,8 @@ func GenerateCommitMessage(cfg config.Config, diff string) (string, error) {
 	}
 }
 
+// GenerateCommitMessageAzure generates a commit message using the Azure Language Learning Model.
+// It takes an API key, a config.Config object, and a string representing the diff as input.
 func GenerateCommitMessageAzure(apikey string, cfg config.Config, diff string) (string, error) {
 	maxTokens := int32(cfg.Tokens)
 	keyCredential := azcore.NewKeyCredential(apikey)
@@ -97,6 +99,9 @@ func GenerateCommitMessageAzure(apikey string, cfg config.Config, diff string) (
 	return messageContent, nil
 }
 
+// GenerateCommitMessageAzureAD generates a commit message using the Azure Language Learning
+// Model with Azure Active Directory authentication.
+// It takes a config.Config object and a string representing the diff as input.
 func GenerateCommitMessageAzureAD(cfg config.Config, diff string) (string, error) {
 	maxTokens := int32(cfg.Tokens)
 	tokenCredential, err := azidentity.NewDefaultAzureCredential(nil)
@@ -162,6 +167,8 @@ func GenerateCommitMessageAzureAD(cfg config.Config, diff string) (string, error
 	return messageContent, nil
 }
 
+// GenerateCommitMessageOpenAI generates a commit message using the OpenAI Language Learning Model.
+// It takes an API key, a config.Config object, and a string representing the diff as input.
 func GenerateCommitMessageOpenAI(apiKey string, cfg config.Config, diff string) (string, error) {
 	client := openai.NewClient(
 		option.WithAPIKey(apiKey), // defaults to os.LookupEnv("OPENAI_API_KEY")
@@ -170,7 +177,7 @@ func GenerateCommitMessageOpenAI(apiKey string, cfg config.Config, diff string) 
 		Messages: openai.F([]openai.ChatCompletionMessageParamUnion{
 			openai.UserMessage(diff),
 		}),
-		Model: openai.F(openai.ChatModelGPT4),
+		Model: openai.F(cfg.ModelDeploymentName),
 	})
 	if err != nil {
 		panic(err.Error())

--- a/internal/llm/llm.go
+++ b/internal/llm/llm.go
@@ -1,3 +1,4 @@
+// Package llm provides functionality for interacting with the Language Learning Model.
 package llm
 
 import (
@@ -16,6 +17,12 @@ import (
 	"github.com/openai/openai-go/option"
 )
 
+// GenerateCommitMessage generates a commit message based on the provided configuration and diff.
+// It takes a config.Config object and a string representing the diff as input.
+// The function returns a string containing the generated commit message and an error if any.
+// The commit message is generated based on the connection type specified in the config.Config object.
+// Supported connection types are "azure", "azure_ad", and "openai".
+// If the connection type is not supported, the function returns an empty string and an error indicating the unsupported connection type.
 func GenerateCommitMessage(cfg config.Config, diff string) (string, error) {
 	apikey := os.Getenv("API_KEY")
 	switch cfg.ConnectionType {

--- a/internal/llm/llm.go
+++ b/internal/llm/llm.go
@@ -6,11 +6,12 @@ import (
 	"log"
 	"os"
 
+	"gic/internal/config"
+
 	"github.com/Azure/azure-sdk-for-go/sdk/ai/azopenai"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
-	"github.com/jsburckhardt/gic/internal/config"
 	"github.com/openai/openai-go"
 	"github.com/openai/openai-go/option"
 )

--- a/main.go
+++ b/main.go
@@ -1,0 +1,15 @@
+// main package for the gic
+package main
+
+import (
+	"gic/cmd"
+)
+
+var (
+	version = "edge"
+	commit  = "n/a"
+)
+
+func main() {
+	cmd.Execute(version, commit)
+}

--- a/main.go
+++ b/main.go
@@ -11,5 +11,8 @@ var (
 )
 
 func main() {
-	cmd.Execute(version, commit)
+	err := cmd.Execute(version, commit)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/makefile
+++ b/makefile
@@ -1,2 +1,5 @@
 lint:
 	golangci-lint run ./...
+
+fmt:
+	gofmt -l -w -s 


### PR DESCRIPTION
- Introduce main package and cmd package for command execution in gic.
- Rename `cmd/gic/main.go` to `cmd/root.go` for a clearer command structure.
- Add command execution logic and persistent flags.

chore(devcontainer): update devcontainer settings

- Update `.devcontainer/devcontainer.json` with Golang tooling settings and editor preferences.
- Minor cleanup and commenting out unnecessary lines.

chore(gitignore): update gitignore rules

- Add `gic` to `.gitignore` to prevent tracking of the binary.

ci(linter): enable revive linter

- Update `.golangci.yml` to include `revive` linter.

refactor(modules): update go module references

- Change module reference from `github.com/jsburckhardt/gic` to `gic`.
- Adjust dependencies in `go.mod` accordingly.

docs(goreleaser): comment out go generate step

- Comment out the `go generate` step in `.goreleaser.yaml`.

test(git): update import paths in git tests

- Adjust import paths in `internal/git/git_test.go` to match the updated module structure.