### PR TITLE
chore(ci, goreleaser): update CI workflow to install goreleaser

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,6 +64,11 @@ jobs:
         with:
           node-version: "lts/*"
 
+      # install goreleaser
+      - name: Install goreleaser
+        run: |
+          curl -sfL https://goreleaser.com/static/run | bash
+
       - name: Semantic Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -20,8 +20,10 @@ builds:
       - CGO_ENABLED=0
     goos:
       - linux
-      - windows
       - darwin
+
+sboms:
+  - artifacts: archive
 
 archives:
   - format: tar.gz

--- a/.releaserc
+++ b/.releaserc
@@ -9,5 +9,4 @@ plugins:
 - - "@semantic-release/exec"
   - publishCmd: |
       echo "${nextRelease.notes}" > /tmp/release-notes.md
-      curl -sfL https://goreleaser.com/static/run | bash
       goreleaser release --release-notes /tmp/release-notes.md --clean


### PR DESCRIPTION

This pull request includes several changes to the CI/CD pipeline and release configuration files. The most important changes involve adding a step to install `goreleaser` in the GitHub Actions workflow, updating the `goreleaser` configuration to include SBOMs, and removing redundant installation steps from the release process.

CI/CD pipeline improvements:

* [`.github/workflows/ci.yaml`](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddR67-R71): Added a step to install `goreleaser` in the GitHub Actions workflow.

Release configuration updates:

* [`.goreleaser.yaml`](diffhunk://#diff-7326b55c062b0f46fe9e39aace0a25f4515cf206040fb91a6fd2cae839f5e826L23-R27): Added SBOM generation for archives and removed Windows from the list of target OSes.
* [`.releaserc`](diffhunk://#diff-644a8fae29c8e8b6ad5405a2e66c718a3b27f2e12581b7c5e00396d32b3e5cdeL12): Removed redundant `goreleaser` installation step from the release process.