### PR TITLE
chore(ci): update goreleaser installation method in CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,8 +67,9 @@ jobs:
       # install goreleaser
       - name: Install goreleaser
         run: |
-          curl -sfL https://goreleaser.com/static/run | bash
-
+          echo 'deb [trusted=yes] https://repo.goreleaser.com/apt/ /' | sudo tee /etc/apt/sources.list.d/goreleaser.list
+          sudo apt update
+          sudo apt install goreleaser
       - name: Semantic Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request includes a change to the CI workflow configuration to update the method of installing `goreleaser`.

CI Workflow Update:

* [`.github/workflows/ci.yaml`](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL70-R72): Changed the installation method for `goreleaser` from using a direct download script to using the APT package manager for better reliability and security.