### PR TITLE
feat(commands): implement pull request flag to generate commit message against main branch

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
 	"name": "gic",
 	"image": "mcr.microsoft.com/devcontainers/go:dev-1.23",
 	"runArgs": [
-		"--gpus", "all"
+		// "--gpus", "all"
 	],
 	"hostRequirements": {
 	  "cpus": 4,
@@ -17,9 +17,9 @@
 		"ghcr.io/devcontainers/features/azure-cli:1": {
 			"installBicep": true
 		},
-        "ghcr.io/prulloac/devcontainer-features/ollama:1": {
-            "pull": "phi3.5"
-        },
+        // "ghcr.io/prulloac/devcontainer-features/ollama:1": {
+        //     "pull": "phi3.5"
+        // },
 		"ghcr.io/stuartleeks/dev-container-features/shell-history:0": {}
 
 	},

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,6 +12,18 @@
             "program": "main.go",
             "cwd": "/workspaces/gic",
             "envFile": "${workspaceFolder}/.env",
+        },
+        {
+            "name": "pr",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "main.go",
+            "args": [
+                "-p",
+            ],
+            "cwd": "/workspaces/gic",
+            "envFile": "${workspaceFolder}/.env",
         }
     ]
 }

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -6,6 +6,7 @@ import (
 	"gic/internal/config"
 	"gic/internal/logger"
 	"os/exec"
+	"strings"
 )
 
 // GetStagedChanges returns the staged changes in the git repository.
@@ -20,13 +21,54 @@ func GetStagedChanges() (string, error) {
 	return string(out), nil
 }
 
+// GetDiffWithMain returns the diff between the current branch and the main branch.
+func GetDiffWithMain() (string, error) {
+	// check if it is behind and if it is, return error saying it is behind origin/main
+	_, err := isLocalMainBehind()
+	if err != nil {
+		return "", err
+	}
+	cmd := exec.Command("git", "diff", "origin/main")
+	output, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return string(output), nil
+}
+
+// IsLocalMainBehind checks if the local main branch is behind the origin main branch.
+func isLocalMainBehind() (bool, error) {
+	// Fetch the latest changes from the origin
+	cmd := exec.Command("git", "fetch", "origin")
+	if err := cmd.Run(); err != nil {
+		return false, err
+	}
+
+	// Compare the local main branch with the origin main branch
+	cmd = exec.Command("git", "rev-list", "--left-right", "--count", "main...origin/main")
+	out, err := cmd.Output()
+	if err != nil {
+		return false, err
+	}
+
+	// Parse the output
+	parts := strings.Fields(string(out))
+	if len(parts) != 2 {
+		return false, err
+	}
+
+	// Check if the local main branch is behind
+	behind := parts[1] != "0"
+	return behind, nil
+}
+
 // Commit commits the staged changes with the generated message.
 // it will only print the message unless commit is set to true.
-func Commit(message string, cfg config.Config) error {
+func Commit(message string, cfg config.Config, pr bool) error {
 	l := logger.GetLogger()
 	var err error
 	cmd := exec.Command("git", "commit", "-m", message)
-	if cfg.ShouldCommit {
+	if cfg.ShouldCommit && !pr {
 		l.Debug("ShouldCommit True. Committing changes...")
 		l.Debug("Commit message: " + message)
 		var stderr bytes.Buffer


### PR DESCRIPTION
This pull request introduces several changes to support generating commit messages for pull requests and enhance the development environment configuration. The most important changes include adding a new flag for pull requests, modifying the commit logic, and updating the development container configuration.

Enhancements for pull request support:

* [`cmd/root.go`](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR19): Added a new `--pull-request` flag to generate commit messages comparing against the main branch. Updated the `executeCmd` function to handle this flag and retrieve the appropriate git diff. [[1]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR19) [[2]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR62-R87) [[3]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fL87-R101) [[4]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR119-R127)
* [`internal/git/git.go`](diffhunk://#diff-4916998d9832575e2e2bd8f23267ab0a3e229b3c0de0cc24761331c69e80abcdR9): Added `GetDiffWithMain` and `isLocalMainBehind` functions to get the diff between the current branch and the main branch and check if the local main branch is behind the origin. Modified the `Commit` function to handle the new pull request logic. [[1]](diffhunk://#diff-4916998d9832575e2e2bd8f23267ab0a3e229b3c0de0cc24761331c69e80abcdR9) [[2]](diffhunk://#diff-4916998d9832575e2e2bd8f23267ab0a3e229b3c0de0cc24761331c69e80abcdR24-R71)

Development environment configuration updates:

* [`.devcontainer/devcontainer.json`](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L5-R5): Commented out GPU support and the `ollama` feature to streamline the setup. [[1]](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L5-R5) [[2]](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L20-R22)
* [`.vscode/launch.json`](diffhunk://#diff-bd5430ee7c51dc892a67b3f2829d1f5b6d223f0fd48b82322cfd45baf9f5e945R15-R26): Added a new launch configuration for pull requests to facilitate debugging.