### PR TITLE
feat(git): enhance diff handling based on configuration

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -68,21 +68,12 @@ func executeCmd(_ *cobra.Command, _ []string) error {
 	}
 	l.Debug("Finish loading configuration")
 
-	var gitDiff string
-	if pullRequest {
-		l.Debug("Start getting diff with main branch")
-		gitDiff, err = git.GetDiffWithMain()
-		if err != nil {
-			return err
-		}
-		l.Debug("Finish getting diff with main branch")
-	} else {
-		l.Debug("Start getting staged changes")
-		gitDiff, err = git.GetStagedChanges()
-		if err != nil {
-			return err
-		}
-		l.Debug("Finish getting staged changes")
+	// Include the pullRequest flag in the configuration
+	cfg.PR = pullRequest
+
+	gitDiff, err := git.GetGitDiff(cfg)
+	if err != nil {
+		return err
 	}
 
 	l.Debug("Start generating commit message")
@@ -93,12 +84,8 @@ func executeCmd(_ *cobra.Command, _ []string) error {
 	if commitMessage == "### NO STAGED CHAGES ###" {
 		return nil
 	}
-	l.Debug("Finish generating commit message")
-	l.Debug("Start validating commit message includes changes")
-
 	l.Info("commit message: " + commitMessage)
-	l.Debug("Finish validating commit message includes changes")
-	return git.Commit(commitMessage, cfg, pullRequest)
+	return git.Commit(commitMessage, cfg)
 }
 
 func setVersion() {
@@ -124,5 +111,4 @@ func init() {
 		false,
 		"generate a commit message comparing against main branch",
 	)
-
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,8 +21,9 @@ type Config struct {
 	LLMInstructions     string `mapstructure:"llm_instructions"`
 	ConnectionType      string `mapstructure:"connection_type"`
 	AzureEndpoint       string `mapstructure:"azure_endpoint"`
-	ShouldCommit        bool   `mapstructure:"should_commit"`
 	Tokens              int    `mapstructure:"tokens"`
+	ShouldCommit        bool   `mapstructure:"should_commit"`
+	PR                  bool   `mapstructure:"pr"`
 }
 
 // LoadConfig loads the configuration from a YAML file and


### PR DESCRIPTION
Refactor the diff retrieval logic to use a unified function `GetGitDiff` that determines whether to get the diff from the main branch or the staged changes based on the configuration's `PR` flag. Additionally, update the `Config` structure to include the `PR` field for managing this behavior.

BREAKING CHANGE: Changes the `Commit` function by removing the `pr` parameter. Now, the function relies solely on the `ShouldCommit` and `PR` fields in the configuration.