### PR TITLE
feat(internal/llm): update OpenAI API key configuration for Azure integration

### DIFF
--- a/internal/llm/llm.go
+++ b/internal/llm/llm.go
@@ -85,7 +85,7 @@ func GenerateCommitMessageAzure(cfg config.Config, diff string) (string, error) 
 	var err error
 
 	if cfg.ConnectionConfig.AzureAuthenticationType == "api_key" {
-		keyCredential := azcore.NewKeyCredential(cfg.ConnectionConfig.OpenAIAPIKey)
+		keyCredential := azcore.NewKeyCredential(cfg.ConnectionConfig.AzureOpenAIAPIKey)
 		client, err = azopenai.NewClientWithKeyCredential(cfg.ConnectionConfig.AzureOpenAIEndpoint, keyCredential, nil)
 	} else if cfg.ConnectionConfig.AzureAuthenticationType == "azure_ad" {
 		tokenCredential, tokenErr := azidentity.NewDefaultAzureCredential(nil)


### PR DESCRIPTION
This pull request includes a change to the `GenerateCommitMessageAzure` function in the `internal/llm/llm.go` file. The change updates the authentication key used for Azure API connections.

Authentication key update:

* [`internal/llm/llm.go`](diffhunk://#diff-15e84642b9ee7cbb81fbfc09f439cc544bcabb6fc29b0835f8a31c77802d6aebL88-R88): Changed the key credential from `cfg.ConnectionConfig.OpenAIAPIKey` to `cfg.ConnectionConfig.AzureOpenAIAPIKey` to correctly use the Azure-specific API key.